### PR TITLE
Add countdown timer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # service-4.0
+
+This repository contains a simple shell script to run a countdown timer from the
+current time in the Sao Paulo time zone until midnight.
+
+## Usage
+
+Run `./countdown_to_midnight.sh` to start the countdown. The script prints the
+remaining minutes and seconds until midnight and updates every second.
+
+A quick calculation for reference: 30% of 500 dollars is $150.

--- a/countdown_to_midnight.sh
+++ b/countdown_to_midnight.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Countdown timer to midnight in Sao Paulo timezone
+current=$(TZ=America/Sao_Paulo date +%s)
+midnight=$(TZ=America/Sao_Paulo date -d 'tomorrow 00:00' +%s)
+diff=$((midnight - current))
+while [ $diff -gt 0 ]; do
+  printf "Remaining: %02d:%02d\r" $((diff/60)) $((diff%60))
+  sleep 1
+  diff=$((diff-1))
+done
+printf "Remaining: 00:00\n"


### PR DESCRIPTION
## Summary
- add `countdown_to_midnight.sh` script to show a countdown timer for Brazil/Sao_Paulo timezone
- document the script and include example 30% calculation in README

## Testing
- `bash -c 'diff=$(($(TZ=America/Sao_Paulo date -d "tomorrow 00:00" +%s) - $(TZ=America/Sao_Paulo date +%s))); min=$((diff/60)); sec=$((diff%60)); echo "Minutes until midnight in Sao Paulo: $min"; for i in {0..3}; do printf "Remaining: %02d:%02d\n" $min $sec; sleep 1; diff=$((diff-1)); min=$((diff/60)); sec=$((diff%60)); done'`
- `echo $((500 * 30 / 100))`


------
https://chatgpt.com/codex/tasks/task_e_687aedc8270c832d9c839ec263ff71ef