### PR TITLE
Initialize React Native prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
-# service-4.0
+# Gonzales C Service 4.0
+
+Prototype mobile app built with React Native (Expo) to identify products via photo and description and suggest market prices.
+
+## Features
+- Capture product photo using device camera
+- User description input
+- Average market price calculation (placeholder API)
+- Urgent price suggestion (10% below average)
+- Custom price entry
+- Firebase authentication (Google placeholder)
+- Modular architecture prepared for future integrations
+- Portuguese and Spanish support using `i18next`
+
+## Project Structure
+```
+src/
+  App.js                     Main navigation
+  index.js                   Entry point for Expo
+  core/
+    config/
+    hooks/
+    utils/
+  modules/
+    product/                 Product capture and APIs
+      components/
+      services/
+      screens/
+    pricing/                 Price calculation flows
+      strategies/
+      market-data/
+    auth/                    Authentication services
+      components/
+      services/
+  locales/                   i18n resources
+    pt/
+    es/
+  shared/                    Reusable components
+    components/
+    styles/
+package.json                 Project dependencies
+```
+
+## Getting Started
+1. Install dependencies with `npm install` (Expo CLI required).
+2. Run `npm start` to launch the development server.
+3. The app will open in Expo Go or an emulator.
+
+Backend and delivery zone data are prepared separately in PostgreSQL and can be connected through the `fetchAveragePrice` service.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "gonzales-c-service-4.0",
+  "version": "0.1.0",
+  "main": "src/index.js",
+  "private": true,
+  "scripts": {
+    "start": "expo start"
+  },
+  "dependencies": {
+    "expo": "^50.0.0",
+    "expo-image-picker": "^15.0.0",
+    "expo-localization": "^15.0.0",
+    "react": "18.2.0",
+    "react-native": "0.73.0",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/native-stack": "^6.9.12",
+    "@tensorflow/tfjs": "^4.16.0",
+    "@tensorflow-models/mobilenet": "^2.2.0",
+    "expo-camera": "^15.0.0",
+    "i18next": "^23.10.0",
+    "react-i18next": "^13.2.0"
+  }
+}

--- a/src/App.js
+++ b/src/App.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import HomeScreen from './modules/product/screens/HomeScreen';
+import PriceScreen from './modules/pricing/screens/PriceScreen';
+import './locales/i18n';
+
+const Stack = createNativeStackNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="Home" component={HomeScreen} />
+        <Stack.Screen name="Price" component={PriceScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,3 @@
+import { registerRootComponent } from 'expo';
+import App from './App';
+registerRootComponent(App);

--- a/src/locales/es/translations.json
+++ b/src/locales/es/translations.json
@@ -1,0 +1,10 @@
+{
+  "capturePhoto": "Tomar foto",
+  "describeProduct": "Describe el producto",
+  "checkPrice": "Consultar Precio",
+  "averagePrice": "Precio promedio",
+  "urgentPrice": "Precio urgente",
+  "customPrice": "Precio personalizado",
+  "loading": "Cargando...",
+  "confirm": "Confirmar"
+}

--- a/src/locales/i18n.js
+++ b/src/locales/i18n.js
@@ -1,0 +1,23 @@
+import * as Localization from 'expo-localization';
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+
+import pt from './pt/translations.json';
+import es from './es/translations.json';
+
+const resources = {
+  pt: { translation: pt },
+  es: { translation: es },
+};
+
+i18n
+  .use(initReactI18next)
+  .init({
+    compatibilityJSON: 'v3',
+    resources,
+    lng: Localization.locale.startsWith('es') ? 'es' : 'pt',
+    fallbackLng: 'pt',
+    interpolation: { escapeValue: false },
+  });
+
+export default i18n;

--- a/src/locales/pt/translations.json
+++ b/src/locales/pt/translations.json
@@ -1,0 +1,10 @@
+{
+  "capturePhoto": "Capturar Foto",
+  "describeProduct": "Descreva o produto",
+  "checkPrice": "Consultar Preço",
+  "averagePrice": "Preço médio",
+  "urgentPrice": "Preço urgente",
+  "customPrice": "Preço personalizado",
+  "loading": "Carregando...",
+  "confirm": "Confirmar"
+}

--- a/src/modules/auth/services/authService.js
+++ b/src/modules/auth/services/authService.js
@@ -1,0 +1,7 @@
+/**
+ * Firebase authentication placeholder.
+ */
+export async function signInWithGoogle() {
+  // TODO: integrate with Firebase Auth
+  console.log('Google sign in');
+}

--- a/src/modules/pricing/screens/PriceScreen.js
+++ b/src/modules/pricing/screens/PriceScreen.js
@@ -1,0 +1,51 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+import { fetchAveragePrice } from '../../product/services/productApi';
+import { useTranslation } from 'react-i18next';
+import '../../../locales/i18n';
+
+export default function PriceScreen({ route }) {
+  const { t } = useTranslation();
+  const { image, description } = route.params;
+  const [average, setAverage] = useState(null);
+  const [customPrice, setCustomPrice] = useState('');
+
+  useEffect(() => {
+    async function load() {
+      const price = await fetchAveragePrice({ image, description });
+      setAverage(price);
+    }
+    load();
+  }, [image, description]);
+
+  if (!average) {
+    return (
+      <View style={styles.container}>
+        <Text>{t('loading')}</Text>
+      </View>
+    );
+  }
+
+  const urgentPrice = (average * 0.9).toFixed(2);
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.label}>{t('averagePrice')}: R$ {average.toFixed(2)}</Text>
+      <Text style={styles.label}>{t('urgentPrice')}: R$ {urgentPrice}</Text>
+      <TextInput
+        placeholder={t('customPrice')}
+        value={customPrice}
+        onChangeText={setCustomPrice}
+        keyboardType="numeric"
+        style={styles.input}
+      />
+      <Button title={t('confirm')} onPress={() => {}} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 16 },
+  label: { fontSize: 18, marginVertical: 8 },
+  input: { borderWidth: 1, padding: 8, width: '100%', marginVertical: 10 },
+});

--- a/src/modules/product/screens/HomeScreen.js
+++ b/src/modules/product/screens/HomeScreen.js
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import { View, TextInput, Button, Image, StyleSheet } from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
+import { useTranslation } from 'react-i18next';
+import '../../../locales/i18n';
+
+export default function HomeScreen({ navigation }) {
+  const { t } = useTranslation();
+  const [image, setImage] = useState(null);
+  const [description, setDescription] = useState('');
+
+  const pickImage = async () => {
+    const result = await ImagePicker.launchCameraAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      quality: 0.5,
+    });
+    if (!result.canceled) {
+      setImage(result.assets[0].uri);
+    }
+  };
+
+  const handleSubmit = () => {
+    navigation.navigate('Price', { image, description });
+  };
+
+  return (
+    <View style={styles.container}>
+      <Button title={t('capturePhoto')} onPress={pickImage} />
+      {image && <Image source={{ uri: image }} style={styles.preview} />}
+      <TextInput
+        placeholder={t('describeProduct')}
+        value={description}
+        onChangeText={setDescription}
+        style={styles.input}
+      />
+      <Button title={t('checkPrice')} onPress={handleSubmit} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 16 },
+  preview: { width: 200, height: 200, marginVertical: 10 },
+  input: { borderWidth: 1, padding: 8, width: '100%', marginVertical: 10 },
+});

--- a/src/modules/product/services/productApi.js
+++ b/src/modules/product/services/productApi.js
@@ -1,0 +1,11 @@
+/**
+ * Placeholder API module.
+ * Here we would integrate with PostgreSQL and image recognition services
+ * to retrieve product information and price data.
+ */
+export async function fetchAveragePrice({ image, description }) {
+  // TODO: integrate with backend via REST or GraphQL
+  console.log('Fetching price for', { image, description });
+  // returning mocked value for prototype
+  return Promise.resolve(100.0);
+}


### PR DESCRIPTION
## Summary
- restructure folders and move entry files to `src`
- update imports for new locations
- document revised directory layout in README
- add placeholders for future dependencies
- switch to `i18next` for translations

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_68804aa906ac832db2cc9efbfe31a8d6